### PR TITLE
Remove U.S. Minor Outer Islands

### DIFF
--- a/geodata/state.txt
+++ b/geodata/state.txt
@@ -54,5 +54,4 @@ STATE|STUSAB|STATE_NAME|STATENS
 66|GU|Guam|01802705
 69|MP|Northern Mariana Islands|01779809
 72|PR|Puerto Rico|01779808
-74|UM|U.S. Minor Outlying Islands|01878752
 78|VI|U.S. Virgin Islands|01802710

--- a/states/u.s._minor_outlying_islands/info.toml
+++ b/states/u.s._minor_outlying_islands/info.toml
@@ -1,3 +1,0 @@
-fips_code = 74
-name = "U.S. Minor Outlying Islands"
-postal_code = "UM"


### PR DESCRIPTION
Updated state.txt AND removed the folder in states so the u.s._minor_outlying_islands/index.html is not generated.