### PR TITLE
Fixes Absentee.overseas-militay and Sources in CO

### DIFF
--- a/scripts/election.py
+++ b/scripts/election.py
@@ -20,8 +20,8 @@ for key in elections:
 dates = []
 
 methods = ["received_by", "in_person_by", "postmarked_by", "online_by"]
-deadlines = {"absentee": ["application"],
-             "poll": ["early", "overseas_military"],
+deadlines = {"absentee": ["application", "overseas_military"],
+             "poll": ["early"],
              "registration" : []}
 
 # Load per-state data.
@@ -153,9 +153,9 @@ deadline_descriptions = {
     "absentee.application.postmarked_by": "Last day to postmark absentee applications",
     "absentee.application.received_by": "Last day for election officials to receive absentee applications",
     "absentee.application.in_person_by": "Last day to hand deliver an absentee applications",
+    "absentee.overseas_military.received_by": "Last day for election officials to receive military and overseas ballots",
     "poll.in_person_by": "Last day to vote in person",
     "poll.early.in_person_by": "Last day to vote early in person",
-    "poll.overseas_military.received_by": "Last day for election officials to receive military and overseas ballots",
     "registration.received_by": "Last day for election officials to receive voter registration form",
     "registration.postmarked_by": "Last day to postmark voter registration form",
     "registration.in_person_by": "Last day to register to vote in person",

--- a/states/colorado/elections.toml
+++ b/states/colorado/elections.toml
@@ -11,30 +11,29 @@ original_date = 2020-06-30
 [20200630.absentee]
 received_by = 2020-06-30T19:00:00
 in_person_by = 2020-06-30T19:00:00
-sources = "https://www.sos.state.co.us/pubs/elections/calendar.html"
+sources = ["https://www.sos.state.co.us/pubs/elections/calendar.html"]
 
 [20200630.absentee.application]
 received_by = 2020-06-22
-sources = "https://www.sos.state.co.us/pubs/elections/calendar.html"
+sources = ["https://www.sos.state.co.us/pubs/elections/calendar.html"]
 
 [20200630.registration]
 received_by = 2020-06-22
 in_person_by = 2020-06-30
-sources = "https://www.sos.state.co.us/pubs/elections/calendar.html"
+sources = ["https://www.sos.state.co.us/pubs/elections/calendar.html"]
 
 [20200630.poll.early]
 in_person_start = 2020-06-23
 in_person_by = 2020-06-30
-sources = "https://www.sos.state.co.us/pubs/elections/calendar.html"
+sources = ["https://www.sos.state.co.us/pubs/elections/calendar.html"]
 
 [20200630.poll]
 in_person_by = 2020-06-30
-sources = "https://www.sos.state.co.us/pubs/elections/calendar.html"
+sources = ["https://www.sos.state.co.us/pubs/elections/calendar.html"]
 
-[20200630.poll.overseas_military]
+[20200630.absentee.overseas_military]
 received_by = 2020-07-08
-sources = "https://www.sos.state.co.us/pubs/elections/calendar.html"
-
+sources = ["https://www.sos.state.co.us/pubs/elections/calendar.html"]
 
 [20201103]
 date = 2020-11-03
@@ -44,26 +43,26 @@ original_date = 2020-11-03
 [20201103.registration]
 received_by = 2020-10-26
 in_person_by = 2020-11-03
-sources = "https://www.sos.state.co.us/pubs/elections/calendar.html"
+sources = ["https://www.sos.state.co.us/pubs/elections/calendar.html"]
 
 [20201103.absentee]
 received_by = 2020-11-03T19:00:00
 in_person_by = 2020-11-03T19:00:00
-sources = "https://www.sos.state.co.us/pubs/elections/calendar.html"
+sources = ["https://www.sos.state.co.us/pubs/elections/calendar.html"]
 
 [20201103.absentee.application]
 received_by = 2020-10-26
-sources = "https://www.sos.state.co.us/pubs/elections/calendar.html"
+sources = ["https://www.sos.state.co.us/pubs/elections/calendar.html"]
 
 [20201103.poll.early]
 in_person_start = 2020-10-19
 in_person_by = 2020-11-03
-sources = "https://www.sos.state.co.us/pubs/elections/calendar.html"
+sources = ["https://www.sos.state.co.us/pubs/elections/calendar.html"]
 
 [20201103.poll]
 in_person_by = 2020-11-03
-sources = "https://www.sos.state.co.us/pubs/elections/calendar.html"
+sources = ["https://www.sos.state.co.us/pubs/elections/calendar.html"]
 
-[20201103.poll.overseas_military]
+[20201103.absentee.overseas_military]
 received_by = 2020-11-12
-sources = "https://www.sos.state.co.us/pubs/elections/calendar.html"
+sources = ["https://www.sos.state.co.us/pubs/elections/calendar.html"]


### PR DESCRIPTION
* Using [Prettier TOML](https://marketplace.visualstudio.com/items?itemName=bodil.prettier-toml) to keep my white spacing to some standard.
* Fixes #29 
* Related to #30, this corrects CO and election.py to use absentee.overseas_military