### PR TITLE
Fix missing county name

### DIFF
--- a/scripts/generators/json.py
+++ b/scripts/generators/json.py
@@ -18,7 +18,7 @@ def generate(dates, output_filename, *, state_info=None, name=None, description=
         for key in date:
             value = date[key]
             if not isinstance(value, datetime.datetime):
-                continue    
+                continue
             date[key] = value.strftime("%Y-%m-%d")
         if "details" in date:
             del date["details"]

--- a/scripts/generators/json.py
+++ b/scripts/generators/json.py
@@ -18,7 +18,7 @@ def generate(dates, output_filename, *, state_info=None, name=None, description=
         for key in date:
             value = date[key]
             if not isinstance(value, datetime.datetime):
-                continue
+                continue    
             date[key] = value.strftime("%Y-%m-%d")
         if "details" in date:
             del date["details"]
@@ -26,6 +26,7 @@ def generate(dates, output_filename, *, state_info=None, name=None, description=
             date["state"] = states[date["state"]]["name"]
         if state_info:
             date["state"] = state_info["name"]
-
+            if len(path_parts) == 5: # only county files have 5 parts
+                date["county"] = state_info["counties"][f"{path_parts[3]}"]["name"]
     with open(output_filename, "w") as f:
         json.dump(top_level, f)


### PR DESCRIPTION
This ensures when we're generating County JSON files, we set the county name. This will unblock @fede2cr.
It is sort of a hack, but I didn't want to change the generator parameters again without some input.

If we do want to refactor, I think adding a parameter to indicate if it is a Federal, State, or County file we're generating would be helpful. Right now we're inferring this from the content and presence of parameters.