### PR TITLE
Add mn events

### DIFF
--- a/states/minnesota/elections.toml
+++ b/states/minnesota/elections.toml
@@ -8,7 +8,85 @@ date = 2020-08-11
 name = "Congresssional Primary"
 original_date = 2020-08-11
 
+[20200811.registration]
+online_by = 2020-07-21T23:59:00
+received_by = 2020-07-21T17:00:00
+in_person_by = 2020-08-11T20:00:00
+sources = [
+    "https://www.sos.state.mn.us/elections-voting/election-day-voting/",
+    "https://www.sos.state.mn.us/elections-voting/election-day-voting/voting-hours/",
+    "https://www.sos.state.mn.us/elections-voting/register-to-vote/registration-faqs/"
+]
+
+[20200811.absentee.application]
+online_by = 2020-08-10 # Legally this is true, but you'll never receive it.
+received_by = 2020-08-10 # Legally this is true, but you'll never receive it.
+fax_by =  2020-08-10 # Legally this is true, but you'll never receive it.
+email_by =  2020-08-10 # Legally this is true, but you'll never receive it.
+sources = [
+    "https://www.sos.state.mn.us/elections-voting/other-ways-to-vote/vote-early-by-mail/",
+    "https://mnvotes.sos.state.mn.us/ABRegistration/ABRegistrationStep1.aspx"
+]
+
+[20200811.absentee]
+received_start = 2020-06-26
+postmarked_by = 2020-08-10
+receive_by = 2020-08-12 # See "received by your county by the day before the county canvass"
+in_person_start = 2020-06-26
+in_person_by = 2020-08-11T15:00:00
+sources = [
+    "https://www.sos.state.mn.us/election-administration-campaigns/elections-calendar/",
+    "https://www.sos.state.mn.us/elections-voting/other-ways-to-vote/",
+    "https://www.sos.state.mn.us/elections-voting/other-ways-to-vote/vote-early-by-mail/"
+]
+
+[20200811.poll]
+in_person_start = 2020-08-11T07:00:00
+in_person_by = 2020-08-11T20:00:00
+sources = [
+    "https://www.sos.state.mn.us/election-administration-campaigns/elections-calendar/",
+    "https://www.sos.state.mn.us/elections-voting/election-day-voting/voting-hours/",
+]
+
 [20201103]
 date = 2020-11-03
 name = "General"
 original_date = 2020-11-03
+
+[20201103.registration]
+online_by = 2020-10-13T23:59:00
+received_by = 2020-10-13T17:00:00
+in_person_by = 2020-11-03T20:00:00
+sources = [
+    "https://www.sos.state.mn.us/elections-voting/election-day-voting/",
+    "https://www.sos.state.mn.us/elections-voting/election-day-voting/voting-hours/",
+    "https://www.sos.state.mn.us/elections-voting/register-to-vote/registration-faqs/"
+]
+
+[20201103.absentee.application]
+online_by = 2020-11-02 # Legally this is true, but you'll never receive it.
+received_by = 2020-11-02 # Legally this is true, but you'll never receive it.
+fax_by =  2020-11-02 # Legally this is true, but you'll never receive it.
+email_by =  2020-11-02 # Legally this is true, but you'll never receive it.
+sources = [
+    "https://www.sos.state.mn.us/elections-voting/other-ways-to-vote/vote-early-by-mail/",
+    "https://mnvotes.sos.state.mn.us/ABRegistration/ABRegistrationStep1.aspx"
+]
+
+[20201103.absentee]
+receive_start 2020-09-18
+receive_by = 2020-11-02
+in_person_start = 2020-09-18T07:00:00
+in_person_by = 2020-11-02T17:00:00
+sources = [
+    "https://www.sos.state.mn.us/election-administration-campaigns/elections-calendar/",
+    "https://www.sos.state.mn.us/elections-voting/other-ways-to-vote/"
+]
+
+[20201103.poll]
+in_person_start = 2020-11-03T07:00:00
+in_person_by = 2020-11-03T20:00:00
+sources = [
+    "https://www.sos.state.mn.us/election-administration-campaigns/elections-calendar/",
+    "https://www.sos.state.mn.us/elections-voting/election-day-voting/voting-hours/",
+]

--- a/states/minnesota/elections.toml
+++ b/states/minnesota/elections.toml
@@ -74,7 +74,7 @@ sources = [
 ]
 
 [20201103.absentee]
-receive_start 2020-09-18
+receive_start = 2020-09-18
 receive_by = 2020-11-02
 in_person_start = 2020-09-18T07:00:00
 in_person_by = 2020-11-02T17:00:00

--- a/states/minnesota/elections.toml
+++ b/states/minnesota/elections.toml
@@ -19,10 +19,10 @@ sources = [
 ]
 
 [20200811.absentee.application]
-online_by = 2020-08-10 # Legally this is true, but you'll never receive it.
-received_by = 2020-08-10 # Legally this is true, but you'll never receive it.
-fax_by =  2020-08-10 # Legally this is true, but you'll never receive it.
-email_by =  2020-08-10 # Legally this is true, but you'll never receive it.
+online_by = 2020-07-27 # Padded 14 days
+received_by = 2020-07-27 # Padded 14 days
+fax_by =  2020-07-27 # Padded 14 days
+email_by =  2020-07-27 # Padded 14 days
 sources = [
     "https://www.sos.state.mn.us/elections-voting/other-ways-to-vote/vote-early-by-mail/",
     "https://mnvotes.sos.state.mn.us/ABRegistration/ABRegistrationStep1.aspx"
@@ -64,10 +64,10 @@ sources = [
 ]
 
 [20201103.absentee.application]
-online_by = 2020-11-02 # Legally this is true, but you'll never receive it.
-received_by = 2020-11-02 # Legally this is true, but you'll never receive it.
-fax_by =  2020-11-02 # Legally this is true, but you'll never receive it.
-email_by =  2020-11-02 # Legally this is true, but you'll never receive it.
+online_by = 2020-10-19 # Padded 14 days
+received_by = 2020-10-19 # Padded 14 days
+fax_by =  2020-10-19 # Padded 14 days
+email_by =  2020-10-19 # Padded 14 days
 sources = [
     "https://www.sos.state.mn.us/elections-voting/other-ways-to-vote/vote-early-by-mail/",
     "https://mnvotes.sos.state.mn.us/ABRegistration/ABRegistrationStep1.aspx"


### PR DESCRIPTION
As I mentioned in Discord, Minnesota says...  

https://www.sos.state.mn.us/elections-voting/other-ways-to-vote/vote-early-by-mail/
> Application deadline
> You can apply for a ballot any time during the year, except the day of the election. Leave time for election officials to mail your ballot. Your returned ballot must be postmarked on or before Election Day (August 11, 2020) and received by your county by the day before the county canvass, which may take place on the second or third day following the election. 

I didn't see an actual date for received by for absentee though which to my eye means yeah you can legally mail it in 2 days before but you're not going to get a ballot and send it back in time.

We could leave it alone and just publish the rule or we could pad the date back X days.
I think we should just publish the rules. If you want to pad, I suggest 5 days.

I remember @tannewt  saying something about this before. If there's some rule you want to use for consistency just let me know.

Thanks!
Thanks!