### PR TITLE
Schema validation

### DIFF
--- a/scripts/election.py
+++ b/scripts/election.py
@@ -3,6 +3,7 @@ import os
 import tomlkit
 import datetime
 import pendulum
+from election_schema import methods, deadlines
 
 # Below we convert to Python dicts to allow None. We won't write back to TOML
 federal_fn = os.path.join("federal-elections.toml")
@@ -18,11 +19,6 @@ for key in elections:
     elections[key] = election
 
 dates = []
-
-methods = ["received_by", "in_person_by", "postmarked_by", "online_by"]
-deadlines = {"absentee": ["application", "overseas_military"],
-             "poll": ["early"],
-             "registration" : []}
 
 # Load per-state data.
 for state in os.listdir("states/"):

--- a/scripts/election_schema/__init__.py
+++ b/scripts/election_schema/__init__.py
@@ -1,0 +1,6 @@
+#  Keys used in the electon_py parsing
+
+methods = ["received_by", "in_person_by", "postmarked_by", "online_by"]
+deadlines = {"absentee": ["application", "overseas_military"],
+             "poll": ["early"],
+             "registration" : []}

--- a/scripts/schema_validation.py
+++ b/scripts/schema_validation.py
@@ -1,0 +1,58 @@
+"""
+    Validates all keys in all elections.toml files are valid according to
+    the keys in election_schema, plus a few hardcoded values
+
+    It might be that the key is a new key and we've not deciced to what to do
+    with it yet. That might be fine.
+
+    Usually its a typo though.
+
+    NOTE: This doesn't check valid hierarchy, only key names.
+"""
+
+import  os
+import sys
+import tomlkit
+from election_schema import methods, deadlines
+
+# These keys are not specifed in election_schema, but they are also valid.
+all_valid_keys = ["date", "name", "original_date", "results", "sources", ]
+
+# Known invalid keys: These keys are not in-use yet, but we know about them
+# And they're fine.
+known_invalid_keys = ["in_person_start","mailed_out"]
+
+# We need a flat list of keys.
+for method in methods:
+    all_valid_keys.append(method)
+for deadline in deadlines:
+    all_valid_keys.append(deadline)
+    for deadline_type in deadlines[deadline]:
+        all_valid_keys.append(deadline_type)
+
+for state in sorted(os.listdir("states/")):
+    errors = False
+    state_fn = os.path.join("states", state, "elections.toml")
+    if not os.path.exists(state_fn):
+        continue
+    with open(state_fn, "r") as f:
+        state_elections = dict(tomlkit.loads(f.read()))
+    for election in state_elections:
+        state_election = dict(state_elections[election])
+        for state_election_key in state_election:
+            if state_election_key not in all_valid_keys:
+                errors = True
+                print(f"{state_election_key} is a suspicious key in {state}\elections.toml")
+            if state_election_key in deadlines:
+                for state_election_event in state_election[state_election_key]:
+                    if state_election_event not in all_valid_keys:
+                        errors = True
+                        print(f"{state_election_event} is a suspicious key in {state}\elections.toml")
+    if errors:
+        print()
+    errors = False
+
+
+print(f"\nCompare to all valid keys:\n{all_valid_keys}")
+if len(known_invalid_keys) > 0:
+    print(f"\nAnd known accpetable invalid keys:\n{known_invalid_keys}\n")

--- a/scripts/schema_validation.py
+++ b/scripts/schema_validation.py
@@ -42,12 +42,12 @@ for state in sorted(os.listdir("states/")):
         for state_election_key in state_election:
             if state_election_key not in all_valid_keys:
                 errors = True
-                print(f"{state_election_key} is a suspicious key in {state}\elections.toml")
+                print(f"{state_election_key} is a suspicious key in {state}/elections.toml")
             if state_election_key in deadlines:
                 for state_election_event in state_election[state_election_key]:
                     if state_election_event not in all_valid_keys:
                         errors = True
-                        print(f"{state_election_event} is a suspicious key in {state}\elections.toml")
+                        print(f"{state_election_event} is a suspicious key in {state}/elections.toml")
     if errors:
         print()
     errors = False

--- a/scripts/schema_validation.py
+++ b/scripts/schema_validation.py
@@ -55,4 +55,4 @@ for state in sorted(os.listdir("states/")):
 
 print(f"\nCompare to all valid keys:\n{all_valid_keys}")
 if len(known_invalid_keys) > 0:
-    print(f"\nAnd known accpetable invalid keys:\n{known_invalid_keys}\n")
+    print(f"\nAnd known acceptable invalid keys:\n{known_invalid_keys}\n")

--- a/scripts/schema_validation.py
+++ b/scripts/schema_validation.py
@@ -2,7 +2,7 @@
     Validates all keys in all elections.toml files are valid according to
     the keys in election_schema, plus a few hardcoded values
 
-    It might be that the key is a new key and we've not deciced to what to do
+    It might be that the key is a new key and we've not decided to what to do
     with it yet. That might be fine.
 
     Usually its a typo though.


### PR DESCRIPTION
This could also be called the @askpatrickw memorial typo hunter... I wrote it this evening after seeing more typo corrections.  I thought it might be worth sharing, if not, that's fine too I can use it on my own edits. ;-)

Happy to take feedback or corrections on how I did this as well.
Pretty sure putting code in __init__.py is a hack, but I don't really write modules.

From the comments:

> Validates all keys in all elections.toml files are valid according to
> the keys in election_schema, plus a few hardcoded values
> 
> It might be that the key is a new key and we've not decided to what to do
> with it yet. That might be fine.
> 
> Usually its a typo though.
> 
> NOTE: This doesn't check valid hierarchy, only key names.

Sample output on the full site and some test data in AAA state.

```
python scripts/schema_validation.py

hamster is a suspicious key in AAA/elections.toml
recev_by is a suspicious key in AAA/elections.toml
in_person_start is a suspicious key in AAA/elections.toml
postmark_by is a suspicious key in AAA/elections.toml

in_person_start is a suspicious key in alabama/elections.toml
postmark_by is a suspicious key in alabama/elections.toml
in_person_start is a suspicious key in alabama/elections.toml
postmark_by is a suspicious key in alabama/elections.toml

in_person_start is a suspicious key in delaware/elections.toml
in_person_start is a suspicious key in delaware/elections.toml
in_person_start is a suspicious key in delaware/elections.toml
in_person_start is a suspicious key in delaware/elections.toml

in_person_start is a suspicious key in hawaii/elections.toml
in_person_start is a suspicious key in hawaii/elections.toml

receive_by is a suspicious key in kansas/elections.toml
receive_start is a suspicious key in kansas/elections.toml
receive_by is a suspicious key in kansas/elections.toml
receive_by is a suspicious key in kansas/elections.toml
receive_start is a suspicious key in kansas/elections.toml
receive_by is a suspicious key in kansas/elections.toml

in_person_start is a suspicious key in louisiana/elections.toml
in_person_start is a suspicious key in louisiana/elections.toml
in_person_start is a suspicious key in louisiana/elections.toml
in_person_start is a suspicious key in louisiana/elections.toml

source is a suspicious key in maine/elections.toml

received_start is a suspicious key in michigan/elections.toml
in_person_start is a suspicious key in michigan/elections.toml
received_start is a suspicious key in michigan/elections.toml
in_person_start is a suspicious key in michigan/elections.toml

requires is a suspicious key in missouri/elections.toml
source is a suspicious key in missouri/elections.toml

in_person_start is a suspicious key in new_jersey/elections.toml
in_person_start is a suspicious key in new_jersey/elections.toml
in_person_start is a suspicious key in new_jersey/elections.toml
in_person_start is a suspicious key in new_jersey/elections.toml

overseas_received_by is a suspicious key in new_york/elections.toml
change_of_address is a suspicious key in new_york/elections.toml
overseas_received_by is a suspicious key in new_york/elections.toml

in_person_start is a suspicious key in oklahoma/elections.toml
in_person_start is a suspicious key in oklahoma/elections.toml
in_person_start is a suspicious key in oklahoma/elections.toml
in_person_start is a suspicious key in oklahoma/elections.toml
in_person_start is a suspicious key in oklahoma/elections.toml
in_person_start is a suspicious key in oklahoma/elections.toml

in_person_start is a suspicious key in tennessee/elections.toml
in_person_start is a suspicious key in tennessee/elections.toml

in_person_starts is a suspicious key in texas/elections.toml
overseas is a suspicious key in texas/elections.toml
military is a suspicious key in texas/elections.toml

post_marked_by is a suspicious key in utah/elections.toml
post_marked_by is a suspicious key in utah/elections.toml
in_person_start is a suspicious key in utah/elections.toml

mailed_out is a suspicious key in washington/elections.toml
mailed_out is a suspicious key in washington/elections.toml

in_person_start is a suspicious key in wisconsin/elections.toml

Compare to all valid keys:
['date', 'name', 'original_date', 'results', 'sources', 'received_by', 'in_person_by', 'postmarked_by', 'online_by', 'absentee', 'application', 'overseas_military', 'poll', 'early', 'registration']

And known acceptable invalid keys:
['in_person_start', 'mailed_out']
```