### PR TITLE
Nevada events

### DIFF
--- a/states/nevada/elections.toml
+++ b/states/nevada/elections.toml
@@ -7,3 +7,33 @@ original_date = 2020-06-09
 date = 2020-11-03
 name = "General"
 original_date = 2020-11-03
+
+[20201103.registration]
+in_person_by = 2020-10-06
+online_by = 2020-10-29
+postmarked_by = 2020-10-06
+sources = ["https://www.nvsos.gov/sos/home/showdocument?id=8206"]
+
+[20201103.absentee.application]
+received_by = 2020-10-20
+sources = ["https://www.nvsos.gov/sos/home/showdocument?id=8206"]
+
+[20201103.absentee]
+in_person_by = 2020-11-03T19:00:00
+postmarked_by = 2020-11-03
+received_by = 2020-11-10
+sources = [
+  "https://www.nvsos.gov/sos/home/showdocument?id=8206",
+  "https://www.nvsos.gov/sos/elections/voters/absentee-voting",
+]
+
+[20201103.poll.early]
+in_person_by = 2020-10-30
+in_person_start = 2020-10-17
+sources = ["https://www.nvsos.gov/sos/home/showdocument?id=8206"]
+
+[20201103.poll]
+in_person_by = 2020-11-03T19:00:00
+in_person_start = 2020-11-03T07:00:00
+postmarked_by = 2020-11-03
+sources = ["https://www.nvsos.gov/sos/elections/election-information/2020-election/2020-general-election"]


### PR DESCRIPTION

> The Nevada state motto "All for Our Country" was adopted as part of the state seal in the year of 1886. Unfortunately there is no documentation of the reasoning behind the choice of the Nevada state motto.  

My guess is they made up the name while in the place that Vegas would someday be created.

NOTE: Nevada has absentee rules, BUT they are also mailing everyone a ballot this year which sort of nullifies that, but I left it in.